### PR TITLE
Orchestration API support of NFTs

### DIFF
--- a/packages/cosmic-proto/scripts/codegen.cjs
+++ b/packages/cosmic-proto/scripts/codegen.cjs
@@ -47,7 +47,6 @@ telescope({
           'cosmos.autocli.v1',
 
           'cosmos.msg.v1',
-          'cosmos.nft.v1beta1',
           'cosmos.capability.v1beta1',
           'cosmos.orm.v1alpha1',
           'cosmos.orm.v1',

--- a/packages/cosmic-proto/src/codegen/cosmos/bundle.ts
+++ b/packages/cosmic-proto/src/codegen/cosmos/bundle.ts
@@ -47,21 +47,26 @@ import * as _61 from './group/v1/types.js';
 import * as _62 from './mint/v1beta1/genesis.js';
 import * as _63 from './mint/v1beta1/mint.js';
 import * as _64 from './mint/v1beta1/query.js';
-import * as _65 from './params/v1beta1/params.js';
-import * as _66 from './params/v1beta1/query.js';
-import * as _67 from './staking/v1beta1/authz.js';
-import * as _68 from './staking/v1beta1/genesis.js';
-import * as _69 from './staking/v1beta1/query.js';
-import * as _70 from './staking/v1beta1/staking.js';
-import * as _71 from './staking/v1beta1/tx.js';
-import * as _72 from './tx/signing/v1beta1/signing.js';
-import * as _73 from './tx/v1beta1/service.js';
-import * as _74 from './tx/v1beta1/tx.js';
-import * as _75 from './upgrade/v1beta1/query.js';
-import * as _76 from './upgrade/v1beta1/tx.js';
-import * as _77 from './upgrade/v1beta1/upgrade.js';
-import * as _78 from './vesting/v1beta1/tx.js';
-import * as _79 from './vesting/v1beta1/vesting.js';
+import * as _65 from './nft/v1beta1/event.js';
+import * as _66 from './nft/v1beta1/genesis.js';
+import * as _67 from './nft/v1beta1/nft.js';
+import * as _68 from './nft/v1beta1/query.js';
+import * as _69 from './nft/v1beta1/tx.js';
+import * as _70 from './params/v1beta1/params.js';
+import * as _71 from './params/v1beta1/query.js';
+import * as _72 from './staking/v1beta1/authz.js';
+import * as _73 from './staking/v1beta1/genesis.js';
+import * as _74 from './staking/v1beta1/query.js';
+import * as _75 from './staking/v1beta1/staking.js';
+import * as _76 from './staking/v1beta1/tx.js';
+import * as _77 from './tx/signing/v1beta1/signing.js';
+import * as _78 from './tx/v1beta1/service.js';
+import * as _79 from './tx/v1beta1/tx.js';
+import * as _80 from './upgrade/v1beta1/query.js';
+import * as _81 from './upgrade/v1beta1/tx.js';
+import * as _82 from './upgrade/v1beta1/upgrade.js';
+import * as _83 from './vesting/v1beta1/tx.js';
+import * as _84 from './vesting/v1beta1/vesting.js';
 export namespace cosmos {
   export namespace auth {
     export const v1beta1 = {
@@ -183,43 +188,52 @@ export namespace cosmos {
       ..._64,
     };
   }
-  export namespace params {
+  export namespace nft {
     export const v1beta1 = {
       ..._65,
       ..._66,
+      ..._67,
+      ..._68,
+      ..._69,
+    };
+  }
+  export namespace params {
+    export const v1beta1 = {
+      ..._70,
+      ..._71,
     };
   }
   export namespace staking {
     export const v1beta1 = {
-      ..._67,
-      ..._68,
-      ..._69,
-      ..._70,
-      ..._71,
+      ..._72,
+      ..._73,
+      ..._74,
+      ..._75,
+      ..._76,
     };
   }
   export namespace tx {
     export namespace signing {
       export const v1beta1 = {
-        ..._72,
+        ..._77,
       };
     }
     export const v1beta1 = {
-      ..._73,
-      ..._74,
+      ..._78,
+      ..._79,
     };
   }
   export namespace upgrade {
     export const v1beta1 = {
-      ..._75,
-      ..._76,
-      ..._77,
+      ..._80,
+      ..._81,
+      ..._82,
     };
   }
   export namespace vesting {
     export const v1beta1 = {
-      ..._78,
-      ..._79,
+      ..._83,
+      ..._84,
     };
   }
 }

--- a/packages/cosmic-proto/src/codegen/cosmos/nft/v1beta1/event.ts
+++ b/packages/cosmic-proto/src/codegen/cosmos/nft/v1beta1/event.ts
@@ -1,0 +1,310 @@
+//@ts-nocheck
+import { BinaryReader, BinaryWriter } from '../../../binary.js';
+import { isSet } from '../../../helpers.js';
+import { JsonSafe } from '../../../json-safe.js';
+/** EventSend is emitted on Msg/Send */
+export interface EventSend {
+  classId: string;
+  id: string;
+  sender: string;
+  receiver: string;
+}
+export interface EventSendProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.EventSend';
+  value: Uint8Array;
+}
+/** EventSend is emitted on Msg/Send */
+export interface EventSendSDKType {
+  class_id: string;
+  id: string;
+  sender: string;
+  receiver: string;
+}
+/** EventMint is emitted on Mint */
+export interface EventMint {
+  classId: string;
+  id: string;
+  owner: string;
+}
+export interface EventMintProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.EventMint';
+  value: Uint8Array;
+}
+/** EventMint is emitted on Mint */
+export interface EventMintSDKType {
+  class_id: string;
+  id: string;
+  owner: string;
+}
+/** EventBurn is emitted on Burn */
+export interface EventBurn {
+  classId: string;
+  id: string;
+  owner: string;
+}
+export interface EventBurnProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.EventBurn';
+  value: Uint8Array;
+}
+/** EventBurn is emitted on Burn */
+export interface EventBurnSDKType {
+  class_id: string;
+  id: string;
+  owner: string;
+}
+function createBaseEventSend(): EventSend {
+  return {
+    classId: '',
+    id: '',
+    sender: '',
+    receiver: '',
+  };
+}
+export const EventSend = {
+  typeUrl: '/cosmos.nft.v1beta1.EventSend',
+  encode(
+    message: EventSend,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.classId !== '') {
+      writer.uint32(10).string(message.classId);
+    }
+    if (message.id !== '') {
+      writer.uint32(18).string(message.id);
+    }
+    if (message.sender !== '') {
+      writer.uint32(26).string(message.sender);
+    }
+    if (message.receiver !== '') {
+      writer.uint32(34).string(message.receiver);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): EventSend {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEventSend();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.classId = reader.string();
+          break;
+        case 2:
+          message.id = reader.string();
+          break;
+        case 3:
+          message.sender = reader.string();
+          break;
+        case 4:
+          message.receiver = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): EventSend {
+    return {
+      classId: isSet(object.classId) ? String(object.classId) : '',
+      id: isSet(object.id) ? String(object.id) : '',
+      sender: isSet(object.sender) ? String(object.sender) : '',
+      receiver: isSet(object.receiver) ? String(object.receiver) : '',
+    };
+  },
+  toJSON(message: EventSend): JsonSafe<EventSend> {
+    const obj: any = {};
+    message.classId !== undefined && (obj.classId = message.classId);
+    message.id !== undefined && (obj.id = message.id);
+    message.sender !== undefined && (obj.sender = message.sender);
+    message.receiver !== undefined && (obj.receiver = message.receiver);
+    return obj;
+  },
+  fromPartial(object: Partial<EventSend>): EventSend {
+    const message = createBaseEventSend();
+    message.classId = object.classId ?? '';
+    message.id = object.id ?? '';
+    message.sender = object.sender ?? '';
+    message.receiver = object.receiver ?? '';
+    return message;
+  },
+  fromProtoMsg(message: EventSendProtoMsg): EventSend {
+    return EventSend.decode(message.value);
+  },
+  toProto(message: EventSend): Uint8Array {
+    return EventSend.encode(message).finish();
+  },
+  toProtoMsg(message: EventSend): EventSendProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.EventSend',
+      value: EventSend.encode(message).finish(),
+    };
+  },
+};
+function createBaseEventMint(): EventMint {
+  return {
+    classId: '',
+    id: '',
+    owner: '',
+  };
+}
+export const EventMint = {
+  typeUrl: '/cosmos.nft.v1beta1.EventMint',
+  encode(
+    message: EventMint,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.classId !== '') {
+      writer.uint32(10).string(message.classId);
+    }
+    if (message.id !== '') {
+      writer.uint32(18).string(message.id);
+    }
+    if (message.owner !== '') {
+      writer.uint32(26).string(message.owner);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): EventMint {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEventMint();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.classId = reader.string();
+          break;
+        case 2:
+          message.id = reader.string();
+          break;
+        case 3:
+          message.owner = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): EventMint {
+    return {
+      classId: isSet(object.classId) ? String(object.classId) : '',
+      id: isSet(object.id) ? String(object.id) : '',
+      owner: isSet(object.owner) ? String(object.owner) : '',
+    };
+  },
+  toJSON(message: EventMint): JsonSafe<EventMint> {
+    const obj: any = {};
+    message.classId !== undefined && (obj.classId = message.classId);
+    message.id !== undefined && (obj.id = message.id);
+    message.owner !== undefined && (obj.owner = message.owner);
+    return obj;
+  },
+  fromPartial(object: Partial<EventMint>): EventMint {
+    const message = createBaseEventMint();
+    message.classId = object.classId ?? '';
+    message.id = object.id ?? '';
+    message.owner = object.owner ?? '';
+    return message;
+  },
+  fromProtoMsg(message: EventMintProtoMsg): EventMint {
+    return EventMint.decode(message.value);
+  },
+  toProto(message: EventMint): Uint8Array {
+    return EventMint.encode(message).finish();
+  },
+  toProtoMsg(message: EventMint): EventMintProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.EventMint',
+      value: EventMint.encode(message).finish(),
+    };
+  },
+};
+function createBaseEventBurn(): EventBurn {
+  return {
+    classId: '',
+    id: '',
+    owner: '',
+  };
+}
+export const EventBurn = {
+  typeUrl: '/cosmos.nft.v1beta1.EventBurn',
+  encode(
+    message: EventBurn,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.classId !== '') {
+      writer.uint32(10).string(message.classId);
+    }
+    if (message.id !== '') {
+      writer.uint32(18).string(message.id);
+    }
+    if (message.owner !== '') {
+      writer.uint32(26).string(message.owner);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): EventBurn {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEventBurn();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.classId = reader.string();
+          break;
+        case 2:
+          message.id = reader.string();
+          break;
+        case 3:
+          message.owner = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): EventBurn {
+    return {
+      classId: isSet(object.classId) ? String(object.classId) : '',
+      id: isSet(object.id) ? String(object.id) : '',
+      owner: isSet(object.owner) ? String(object.owner) : '',
+    };
+  },
+  toJSON(message: EventBurn): JsonSafe<EventBurn> {
+    const obj: any = {};
+    message.classId !== undefined && (obj.classId = message.classId);
+    message.id !== undefined && (obj.id = message.id);
+    message.owner !== undefined && (obj.owner = message.owner);
+    return obj;
+  },
+  fromPartial(object: Partial<EventBurn>): EventBurn {
+    const message = createBaseEventBurn();
+    message.classId = object.classId ?? '';
+    message.id = object.id ?? '';
+    message.owner = object.owner ?? '';
+    return message;
+  },
+  fromProtoMsg(message: EventBurnProtoMsg): EventBurn {
+    return EventBurn.decode(message.value);
+  },
+  toProto(message: EventBurn): Uint8Array {
+    return EventBurn.encode(message).finish();
+  },
+  toProtoMsg(message: EventBurn): EventBurnProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.EventBurn',
+      value: EventBurn.encode(message).finish(),
+    };
+  },
+};

--- a/packages/cosmic-proto/src/codegen/cosmos/nft/v1beta1/genesis.ts
+++ b/packages/cosmic-proto/src/codegen/cosmos/nft/v1beta1/genesis.ts
@@ -1,0 +1,198 @@
+//@ts-nocheck
+import { Class, ClassSDKType, NFT, NFTSDKType } from './nft.js';
+import { BinaryReader, BinaryWriter } from '../../../binary.js';
+import { JsonSafe } from '../../../json-safe.js';
+import { isSet } from '../../../helpers.js';
+/** GenesisState defines the nft module's genesis state. */
+export interface GenesisState {
+  /** class defines the class of the nft type. */
+  classes: Class[];
+  entries: Entry[];
+}
+export interface GenesisStateProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.GenesisState';
+  value: Uint8Array;
+}
+/** GenesisState defines the nft module's genesis state. */
+export interface GenesisStateSDKType {
+  classes: ClassSDKType[];
+  entries: EntrySDKType[];
+}
+/** Entry Defines all nft owned by a person */
+export interface Entry {
+  /** owner is the owner address of the following nft */
+  owner: string;
+  /** nfts is a group of nfts of the same owner */
+  nfts: NFT[];
+}
+export interface EntryProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.Entry';
+  value: Uint8Array;
+}
+/** Entry Defines all nft owned by a person */
+export interface EntrySDKType {
+  owner: string;
+  nfts: NFTSDKType[];
+}
+function createBaseGenesisState(): GenesisState {
+  return {
+    classes: [],
+    entries: [],
+  };
+}
+export const GenesisState = {
+  typeUrl: '/cosmos.nft.v1beta1.GenesisState',
+  encode(
+    message: GenesisState,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    for (const v of message.classes) {
+      Class.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    for (const v of message.entries) {
+      Entry.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): GenesisState {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGenesisState();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.classes.push(Class.decode(reader, reader.uint32()));
+          break;
+        case 2:
+          message.entries.push(Entry.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): GenesisState {
+    return {
+      classes: Array.isArray(object?.classes)
+        ? object.classes.map((e: any) => Class.fromJSON(e))
+        : [],
+      entries: Array.isArray(object?.entries)
+        ? object.entries.map((e: any) => Entry.fromJSON(e))
+        : [],
+    };
+  },
+  toJSON(message: GenesisState): JsonSafe<GenesisState> {
+    const obj: any = {};
+    if (message.classes) {
+      obj.classes = message.classes.map(e => (e ? Class.toJSON(e) : undefined));
+    } else {
+      obj.classes = [];
+    }
+    if (message.entries) {
+      obj.entries = message.entries.map(e => (e ? Entry.toJSON(e) : undefined));
+    } else {
+      obj.entries = [];
+    }
+    return obj;
+  },
+  fromPartial(object: Partial<GenesisState>): GenesisState {
+    const message = createBaseGenesisState();
+    message.classes = object.classes?.map(e => Class.fromPartial(e)) || [];
+    message.entries = object.entries?.map(e => Entry.fromPartial(e)) || [];
+    return message;
+  },
+  fromProtoMsg(message: GenesisStateProtoMsg): GenesisState {
+    return GenesisState.decode(message.value);
+  },
+  toProto(message: GenesisState): Uint8Array {
+    return GenesisState.encode(message).finish();
+  },
+  toProtoMsg(message: GenesisState): GenesisStateProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.GenesisState',
+      value: GenesisState.encode(message).finish(),
+    };
+  },
+};
+function createBaseEntry(): Entry {
+  return {
+    owner: '',
+    nfts: [],
+  };
+}
+export const Entry = {
+  typeUrl: '/cosmos.nft.v1beta1.Entry',
+  encode(
+    message: Entry,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    for (const v of message.nfts) {
+      NFT.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): Entry {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEntry();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        case 2:
+          message.nfts.push(NFT.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): Entry {
+    return {
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      nfts: Array.isArray(object?.nfts)
+        ? object.nfts.map((e: any) => NFT.fromJSON(e))
+        : [],
+    };
+  },
+  toJSON(message: Entry): JsonSafe<Entry> {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    if (message.nfts) {
+      obj.nfts = message.nfts.map(e => (e ? NFT.toJSON(e) : undefined));
+    } else {
+      obj.nfts = [];
+    }
+    return obj;
+  },
+  fromPartial(object: Partial<Entry>): Entry {
+    const message = createBaseEntry();
+    message.owner = object.owner ?? '';
+    message.nfts = object.nfts?.map(e => NFT.fromPartial(e)) || [];
+    return message;
+  },
+  fromProtoMsg(message: EntryProtoMsg): Entry {
+    return Entry.decode(message.value);
+  },
+  toProto(message: Entry): Uint8Array {
+    return Entry.encode(message).finish();
+  },
+  toProtoMsg(message: Entry): EntryProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.Entry',
+      value: Entry.encode(message).finish(),
+    };
+  },
+};

--- a/packages/cosmic-proto/src/codegen/cosmos/nft/v1beta1/nft.ts
+++ b/packages/cosmic-proto/src/codegen/cosmos/nft/v1beta1/nft.ts
@@ -1,0 +1,294 @@
+//@ts-nocheck
+import { Any, AnySDKType } from '../../../google/protobuf/any.js';
+import { BinaryReader, BinaryWriter } from '../../../binary.js';
+import { isSet } from '../../../helpers.js';
+import { JsonSafe } from '../../../json-safe.js';
+/** Class defines the class of the nft type. */
+export interface Class {
+  /** id defines the unique identifier of the NFT classification, similar to the contract address of ERC721 */
+  id: string;
+  /** name defines the human-readable name of the NFT classification. Optional */
+  name: string;
+  /** symbol is an abbreviated name for nft classification. Optional */
+  symbol: string;
+  /** description is a brief description of nft classification. Optional */
+  description: string;
+  /** uri for the class metadata stored off chain. It can define schema for Class and NFT `Data` attributes. Optional */
+  uri: string;
+  /** uri_hash is a hash of the document pointed by uri. Optional */
+  uriHash: string;
+  /** data is the app specific metadata of the NFT class. Optional */
+  data?: Any;
+}
+export interface ClassProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.Class';
+  value: Uint8Array;
+}
+/** Class defines the class of the nft type. */
+export interface ClassSDKType {
+  id: string;
+  name: string;
+  symbol: string;
+  description: string;
+  uri: string;
+  uri_hash: string;
+  data?: AnySDKType;
+}
+/** NFT defines the NFT. */
+export interface NFT {
+  /** class_id associated with the NFT, similar to the contract address of ERC721 */
+  classId: string;
+  /** id is a unique identifier of the NFT */
+  id: string;
+  /** uri for the NFT metadata stored off chain */
+  uri: string;
+  /** uri_hash is a hash of the document pointed by uri */
+  uriHash: string;
+  /** data is an app specific data of the NFT. Optional */
+  data?: Any;
+}
+export interface NFTProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.NFT';
+  value: Uint8Array;
+}
+/** NFT defines the NFT. */
+export interface NFTSDKType {
+  class_id: string;
+  id: string;
+  uri: string;
+  uri_hash: string;
+  data?: AnySDKType;
+}
+function createBaseClass(): Class {
+  return {
+    id: '',
+    name: '',
+    symbol: '',
+    description: '',
+    uri: '',
+    uriHash: '',
+    data: undefined,
+  };
+}
+export const Class = {
+  typeUrl: '/cosmos.nft.v1beta1.Class',
+  encode(
+    message: Class,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.id !== '') {
+      writer.uint32(10).string(message.id);
+    }
+    if (message.name !== '') {
+      writer.uint32(18).string(message.name);
+    }
+    if (message.symbol !== '') {
+      writer.uint32(26).string(message.symbol);
+    }
+    if (message.description !== '') {
+      writer.uint32(34).string(message.description);
+    }
+    if (message.uri !== '') {
+      writer.uint32(42).string(message.uri);
+    }
+    if (message.uriHash !== '') {
+      writer.uint32(50).string(message.uriHash);
+    }
+    if (message.data !== undefined) {
+      Any.encode(message.data, writer.uint32(58).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): Class {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseClass();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.id = reader.string();
+          break;
+        case 2:
+          message.name = reader.string();
+          break;
+        case 3:
+          message.symbol = reader.string();
+          break;
+        case 4:
+          message.description = reader.string();
+          break;
+        case 5:
+          message.uri = reader.string();
+          break;
+        case 6:
+          message.uriHash = reader.string();
+          break;
+        case 7:
+          message.data = Any.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): Class {
+    return {
+      id: isSet(object.id) ? String(object.id) : '',
+      name: isSet(object.name) ? String(object.name) : '',
+      symbol: isSet(object.symbol) ? String(object.symbol) : '',
+      description: isSet(object.description) ? String(object.description) : '',
+      uri: isSet(object.uri) ? String(object.uri) : '',
+      uriHash: isSet(object.uriHash) ? String(object.uriHash) : '',
+      data: isSet(object.data) ? Any.fromJSON(object.data) : undefined,
+    };
+  },
+  toJSON(message: Class): JsonSafe<Class> {
+    const obj: any = {};
+    message.id !== undefined && (obj.id = message.id);
+    message.name !== undefined && (obj.name = message.name);
+    message.symbol !== undefined && (obj.symbol = message.symbol);
+    message.description !== undefined &&
+      (obj.description = message.description);
+    message.uri !== undefined && (obj.uri = message.uri);
+    message.uriHash !== undefined && (obj.uriHash = message.uriHash);
+    message.data !== undefined &&
+      (obj.data = message.data ? Any.toJSON(message.data) : undefined);
+    return obj;
+  },
+  fromPartial(object: Partial<Class>): Class {
+    const message = createBaseClass();
+    message.id = object.id ?? '';
+    message.name = object.name ?? '';
+    message.symbol = object.symbol ?? '';
+    message.description = object.description ?? '';
+    message.uri = object.uri ?? '';
+    message.uriHash = object.uriHash ?? '';
+    message.data =
+      object.data !== undefined && object.data !== null
+        ? Any.fromPartial(object.data)
+        : undefined;
+    return message;
+  },
+  fromProtoMsg(message: ClassProtoMsg): Class {
+    return Class.decode(message.value);
+  },
+  toProto(message: Class): Uint8Array {
+    return Class.encode(message).finish();
+  },
+  toProtoMsg(message: Class): ClassProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.Class',
+      value: Class.encode(message).finish(),
+    };
+  },
+};
+function createBaseNFT(): NFT {
+  return {
+    classId: '',
+    id: '',
+    uri: '',
+    uriHash: '',
+    data: undefined,
+  };
+}
+export const NFT = {
+  typeUrl: '/cosmos.nft.v1beta1.NFT',
+  encode(
+    message: NFT,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.classId !== '') {
+      writer.uint32(10).string(message.classId);
+    }
+    if (message.id !== '') {
+      writer.uint32(18).string(message.id);
+    }
+    if (message.uri !== '') {
+      writer.uint32(26).string(message.uri);
+    }
+    if (message.uriHash !== '') {
+      writer.uint32(34).string(message.uriHash);
+    }
+    if (message.data !== undefined) {
+      Any.encode(message.data, writer.uint32(82).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): NFT {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseNFT();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.classId = reader.string();
+          break;
+        case 2:
+          message.id = reader.string();
+          break;
+        case 3:
+          message.uri = reader.string();
+          break;
+        case 4:
+          message.uriHash = reader.string();
+          break;
+        case 10:
+          message.data = Any.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): NFT {
+    return {
+      classId: isSet(object.classId) ? String(object.classId) : '',
+      id: isSet(object.id) ? String(object.id) : '',
+      uri: isSet(object.uri) ? String(object.uri) : '',
+      uriHash: isSet(object.uriHash) ? String(object.uriHash) : '',
+      data: isSet(object.data) ? Any.fromJSON(object.data) : undefined,
+    };
+  },
+  toJSON(message: NFT): JsonSafe<NFT> {
+    const obj: any = {};
+    message.classId !== undefined && (obj.classId = message.classId);
+    message.id !== undefined && (obj.id = message.id);
+    message.uri !== undefined && (obj.uri = message.uri);
+    message.uriHash !== undefined && (obj.uriHash = message.uriHash);
+    message.data !== undefined &&
+      (obj.data = message.data ? Any.toJSON(message.data) : undefined);
+    return obj;
+  },
+  fromPartial(object: Partial<NFT>): NFT {
+    const message = createBaseNFT();
+    message.classId = object.classId ?? '';
+    message.id = object.id ?? '';
+    message.uri = object.uri ?? '';
+    message.uriHash = object.uriHash ?? '';
+    message.data =
+      object.data !== undefined && object.data !== null
+        ? Any.fromPartial(object.data)
+        : undefined;
+    return message;
+  },
+  fromProtoMsg(message: NFTProtoMsg): NFT {
+    return NFT.decode(message.value);
+  },
+  toProto(message: NFT): Uint8Array {
+    return NFT.encode(message).finish();
+  },
+  toProtoMsg(message: NFT): NFTProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.NFT',
+      value: NFT.encode(message).finish(),
+    };
+  },
+};

--- a/packages/cosmic-proto/src/codegen/cosmos/nft/v1beta1/query.ts
+++ b/packages/cosmic-proto/src/codegen/cosmos/nft/v1beta1/query.ts
@@ -1,0 +1,1226 @@
+//@ts-nocheck
+import {
+  PageRequest,
+  PageRequestSDKType,
+  PageResponse,
+  PageResponseSDKType,
+} from '../../base/query/v1beta1/pagination.js';
+import { NFT, NFTSDKType, Class, ClassSDKType } from './nft.js';
+import { BinaryReader, BinaryWriter } from '../../../binary.js';
+import { isSet } from '../../../helpers.js';
+import { JsonSafe } from '../../../json-safe.js';
+/** QueryBalanceRequest is the request type for the Query/Balance RPC method */
+export interface QueryBalanceRequest {
+  classId: string;
+  owner: string;
+}
+export interface QueryBalanceRequestProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.QueryBalanceRequest';
+  value: Uint8Array;
+}
+/** QueryBalanceRequest is the request type for the Query/Balance RPC method */
+export interface QueryBalanceRequestSDKType {
+  class_id: string;
+  owner: string;
+}
+/** QueryBalanceResponse is the response type for the Query/Balance RPC method */
+export interface QueryBalanceResponse {
+  amount: bigint;
+}
+export interface QueryBalanceResponseProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.QueryBalanceResponse';
+  value: Uint8Array;
+}
+/** QueryBalanceResponse is the response type for the Query/Balance RPC method */
+export interface QueryBalanceResponseSDKType {
+  amount: bigint;
+}
+/** QueryOwnerRequest is the request type for the Query/Owner RPC method */
+export interface QueryOwnerRequest {
+  classId: string;
+  id: string;
+}
+export interface QueryOwnerRequestProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.QueryOwnerRequest';
+  value: Uint8Array;
+}
+/** QueryOwnerRequest is the request type for the Query/Owner RPC method */
+export interface QueryOwnerRequestSDKType {
+  class_id: string;
+  id: string;
+}
+/** QueryOwnerResponse is the response type for the Query/Owner RPC method */
+export interface QueryOwnerResponse {
+  owner: string;
+}
+export interface QueryOwnerResponseProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.QueryOwnerResponse';
+  value: Uint8Array;
+}
+/** QueryOwnerResponse is the response type for the Query/Owner RPC method */
+export interface QueryOwnerResponseSDKType {
+  owner: string;
+}
+/** QuerySupplyRequest is the request type for the Query/Supply RPC method */
+export interface QuerySupplyRequest {
+  classId: string;
+}
+export interface QuerySupplyRequestProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.QuerySupplyRequest';
+  value: Uint8Array;
+}
+/** QuerySupplyRequest is the request type for the Query/Supply RPC method */
+export interface QuerySupplyRequestSDKType {
+  class_id: string;
+}
+/** QuerySupplyResponse is the response type for the Query/Supply RPC method */
+export interface QuerySupplyResponse {
+  amount: bigint;
+}
+export interface QuerySupplyResponseProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.QuerySupplyResponse';
+  value: Uint8Array;
+}
+/** QuerySupplyResponse is the response type for the Query/Supply RPC method */
+export interface QuerySupplyResponseSDKType {
+  amount: bigint;
+}
+/** QueryNFTstRequest is the request type for the Query/NFTs RPC method */
+export interface QueryNFTsRequest {
+  classId: string;
+  owner: string;
+  pagination?: PageRequest;
+}
+export interface QueryNFTsRequestProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.QueryNFTsRequest';
+  value: Uint8Array;
+}
+/** QueryNFTstRequest is the request type for the Query/NFTs RPC method */
+export interface QueryNFTsRequestSDKType {
+  class_id: string;
+  owner: string;
+  pagination?: PageRequestSDKType;
+}
+/** QueryNFTsResponse is the response type for the Query/NFTs RPC methods */
+export interface QueryNFTsResponse {
+  nfts: NFT[];
+  pagination?: PageResponse;
+}
+export interface QueryNFTsResponseProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.QueryNFTsResponse';
+  value: Uint8Array;
+}
+/** QueryNFTsResponse is the response type for the Query/NFTs RPC methods */
+export interface QueryNFTsResponseSDKType {
+  nfts: NFTSDKType[];
+  pagination?: PageResponseSDKType;
+}
+/** QueryNFTRequest is the request type for the Query/NFT RPC method */
+export interface QueryNFTRequest {
+  classId: string;
+  id: string;
+}
+export interface QueryNFTRequestProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.QueryNFTRequest';
+  value: Uint8Array;
+}
+/** QueryNFTRequest is the request type for the Query/NFT RPC method */
+export interface QueryNFTRequestSDKType {
+  class_id: string;
+  id: string;
+}
+/** QueryNFTResponse is the response type for the Query/NFT RPC method */
+export interface QueryNFTResponse {
+  nft?: NFT;
+}
+export interface QueryNFTResponseProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.QueryNFTResponse';
+  value: Uint8Array;
+}
+/** QueryNFTResponse is the response type for the Query/NFT RPC method */
+export interface QueryNFTResponseSDKType {
+  nft?: NFTSDKType;
+}
+/** QueryClassRequest is the request type for the Query/Class RPC method */
+export interface QueryClassRequest {
+  classId: string;
+}
+export interface QueryClassRequestProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.QueryClassRequest';
+  value: Uint8Array;
+}
+/** QueryClassRequest is the request type for the Query/Class RPC method */
+export interface QueryClassRequestSDKType {
+  class_id: string;
+}
+/** QueryClassResponse is the response type for the Query/Class RPC method */
+export interface QueryClassResponse {
+  class?: Class;
+}
+export interface QueryClassResponseProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.QueryClassResponse';
+  value: Uint8Array;
+}
+/** QueryClassResponse is the response type for the Query/Class RPC method */
+export interface QueryClassResponseSDKType {
+  class?: ClassSDKType;
+}
+/** QueryClassesRequest is the request type for the Query/Classes RPC method */
+export interface QueryClassesRequest {
+  /** pagination defines an optional pagination for the request. */
+  pagination?: PageRequest;
+}
+export interface QueryClassesRequestProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.QueryClassesRequest';
+  value: Uint8Array;
+}
+/** QueryClassesRequest is the request type for the Query/Classes RPC method */
+export interface QueryClassesRequestSDKType {
+  pagination?: PageRequestSDKType;
+}
+/** QueryClassesResponse is the response type for the Query/Classes RPC method */
+export interface QueryClassesResponse {
+  classes: Class[];
+  pagination?: PageResponse;
+}
+export interface QueryClassesResponseProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.QueryClassesResponse';
+  value: Uint8Array;
+}
+/** QueryClassesResponse is the response type for the Query/Classes RPC method */
+export interface QueryClassesResponseSDKType {
+  classes: ClassSDKType[];
+  pagination?: PageResponseSDKType;
+}
+function createBaseQueryBalanceRequest(): QueryBalanceRequest {
+  return {
+    classId: '',
+    owner: '',
+  };
+}
+export const QueryBalanceRequest = {
+  typeUrl: '/cosmos.nft.v1beta1.QueryBalanceRequest',
+  encode(
+    message: QueryBalanceRequest,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.classId !== '') {
+      writer.uint32(10).string(message.classId);
+    }
+    if (message.owner !== '') {
+      writer.uint32(18).string(message.owner);
+    }
+    return writer;
+  },
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): QueryBalanceRequest {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryBalanceRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.classId = reader.string();
+          break;
+        case 2:
+          message.owner = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryBalanceRequest {
+    return {
+      classId: isSet(object.classId) ? String(object.classId) : '',
+      owner: isSet(object.owner) ? String(object.owner) : '',
+    };
+  },
+  toJSON(message: QueryBalanceRequest): JsonSafe<QueryBalanceRequest> {
+    const obj: any = {};
+    message.classId !== undefined && (obj.classId = message.classId);
+    message.owner !== undefined && (obj.owner = message.owner);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryBalanceRequest>): QueryBalanceRequest {
+    const message = createBaseQueryBalanceRequest();
+    message.classId = object.classId ?? '';
+    message.owner = object.owner ?? '';
+    return message;
+  },
+  fromProtoMsg(message: QueryBalanceRequestProtoMsg): QueryBalanceRequest {
+    return QueryBalanceRequest.decode(message.value);
+  },
+  toProto(message: QueryBalanceRequest): Uint8Array {
+    return QueryBalanceRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryBalanceRequest): QueryBalanceRequestProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.QueryBalanceRequest',
+      value: QueryBalanceRequest.encode(message).finish(),
+    };
+  },
+};
+function createBaseQueryBalanceResponse(): QueryBalanceResponse {
+  return {
+    amount: BigInt(0),
+  };
+}
+export const QueryBalanceResponse = {
+  typeUrl: '/cosmos.nft.v1beta1.QueryBalanceResponse',
+  encode(
+    message: QueryBalanceResponse,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.amount !== BigInt(0)) {
+      writer.uint32(8).uint64(message.amount);
+    }
+    return writer;
+  },
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): QueryBalanceResponse {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryBalanceResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.amount = reader.uint64();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryBalanceResponse {
+    return {
+      amount: isSet(object.amount)
+        ? BigInt(object.amount.toString())
+        : BigInt(0),
+    };
+  },
+  toJSON(message: QueryBalanceResponse): JsonSafe<QueryBalanceResponse> {
+    const obj: any = {};
+    message.amount !== undefined &&
+      (obj.amount = (message.amount || BigInt(0)).toString());
+    return obj;
+  },
+  fromPartial(object: Partial<QueryBalanceResponse>): QueryBalanceResponse {
+    const message = createBaseQueryBalanceResponse();
+    message.amount =
+      object.amount !== undefined && object.amount !== null
+        ? BigInt(object.amount.toString())
+        : BigInt(0);
+    return message;
+  },
+  fromProtoMsg(message: QueryBalanceResponseProtoMsg): QueryBalanceResponse {
+    return QueryBalanceResponse.decode(message.value);
+  },
+  toProto(message: QueryBalanceResponse): Uint8Array {
+    return QueryBalanceResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryBalanceResponse): QueryBalanceResponseProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.QueryBalanceResponse',
+      value: QueryBalanceResponse.encode(message).finish(),
+    };
+  },
+};
+function createBaseQueryOwnerRequest(): QueryOwnerRequest {
+  return {
+    classId: '',
+    id: '',
+  };
+}
+export const QueryOwnerRequest = {
+  typeUrl: '/cosmos.nft.v1beta1.QueryOwnerRequest',
+  encode(
+    message: QueryOwnerRequest,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.classId !== '') {
+      writer.uint32(10).string(message.classId);
+    }
+    if (message.id !== '') {
+      writer.uint32(18).string(message.id);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryOwnerRequest {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryOwnerRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.classId = reader.string();
+          break;
+        case 2:
+          message.id = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryOwnerRequest {
+    return {
+      classId: isSet(object.classId) ? String(object.classId) : '',
+      id: isSet(object.id) ? String(object.id) : '',
+    };
+  },
+  toJSON(message: QueryOwnerRequest): JsonSafe<QueryOwnerRequest> {
+    const obj: any = {};
+    message.classId !== undefined && (obj.classId = message.classId);
+    message.id !== undefined && (obj.id = message.id);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryOwnerRequest>): QueryOwnerRequest {
+    const message = createBaseQueryOwnerRequest();
+    message.classId = object.classId ?? '';
+    message.id = object.id ?? '';
+    return message;
+  },
+  fromProtoMsg(message: QueryOwnerRequestProtoMsg): QueryOwnerRequest {
+    return QueryOwnerRequest.decode(message.value);
+  },
+  toProto(message: QueryOwnerRequest): Uint8Array {
+    return QueryOwnerRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryOwnerRequest): QueryOwnerRequestProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.QueryOwnerRequest',
+      value: QueryOwnerRequest.encode(message).finish(),
+    };
+  },
+};
+function createBaseQueryOwnerResponse(): QueryOwnerResponse {
+  return {
+    owner: '',
+  };
+}
+export const QueryOwnerResponse = {
+  typeUrl: '/cosmos.nft.v1beta1.QueryOwnerResponse',
+  encode(
+    message: QueryOwnerResponse,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    return writer;
+  },
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): QueryOwnerResponse {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryOwnerResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryOwnerResponse {
+    return {
+      owner: isSet(object.owner) ? String(object.owner) : '',
+    };
+  },
+  toJSON(message: QueryOwnerResponse): JsonSafe<QueryOwnerResponse> {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryOwnerResponse>): QueryOwnerResponse {
+    const message = createBaseQueryOwnerResponse();
+    message.owner = object.owner ?? '';
+    return message;
+  },
+  fromProtoMsg(message: QueryOwnerResponseProtoMsg): QueryOwnerResponse {
+    return QueryOwnerResponse.decode(message.value);
+  },
+  toProto(message: QueryOwnerResponse): Uint8Array {
+    return QueryOwnerResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryOwnerResponse): QueryOwnerResponseProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.QueryOwnerResponse',
+      value: QueryOwnerResponse.encode(message).finish(),
+    };
+  },
+};
+function createBaseQuerySupplyRequest(): QuerySupplyRequest {
+  return {
+    classId: '',
+  };
+}
+export const QuerySupplyRequest = {
+  typeUrl: '/cosmos.nft.v1beta1.QuerySupplyRequest',
+  encode(
+    message: QuerySupplyRequest,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.classId !== '') {
+      writer.uint32(10).string(message.classId);
+    }
+    return writer;
+  },
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): QuerySupplyRequest {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQuerySupplyRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.classId = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QuerySupplyRequest {
+    return {
+      classId: isSet(object.classId) ? String(object.classId) : '',
+    };
+  },
+  toJSON(message: QuerySupplyRequest): JsonSafe<QuerySupplyRequest> {
+    const obj: any = {};
+    message.classId !== undefined && (obj.classId = message.classId);
+    return obj;
+  },
+  fromPartial(object: Partial<QuerySupplyRequest>): QuerySupplyRequest {
+    const message = createBaseQuerySupplyRequest();
+    message.classId = object.classId ?? '';
+    return message;
+  },
+  fromProtoMsg(message: QuerySupplyRequestProtoMsg): QuerySupplyRequest {
+    return QuerySupplyRequest.decode(message.value);
+  },
+  toProto(message: QuerySupplyRequest): Uint8Array {
+    return QuerySupplyRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QuerySupplyRequest): QuerySupplyRequestProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.QuerySupplyRequest',
+      value: QuerySupplyRequest.encode(message).finish(),
+    };
+  },
+};
+function createBaseQuerySupplyResponse(): QuerySupplyResponse {
+  return {
+    amount: BigInt(0),
+  };
+}
+export const QuerySupplyResponse = {
+  typeUrl: '/cosmos.nft.v1beta1.QuerySupplyResponse',
+  encode(
+    message: QuerySupplyResponse,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.amount !== BigInt(0)) {
+      writer.uint32(8).uint64(message.amount);
+    }
+    return writer;
+  },
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): QuerySupplyResponse {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQuerySupplyResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.amount = reader.uint64();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QuerySupplyResponse {
+    return {
+      amount: isSet(object.amount)
+        ? BigInt(object.amount.toString())
+        : BigInt(0),
+    };
+  },
+  toJSON(message: QuerySupplyResponse): JsonSafe<QuerySupplyResponse> {
+    const obj: any = {};
+    message.amount !== undefined &&
+      (obj.amount = (message.amount || BigInt(0)).toString());
+    return obj;
+  },
+  fromPartial(object: Partial<QuerySupplyResponse>): QuerySupplyResponse {
+    const message = createBaseQuerySupplyResponse();
+    message.amount =
+      object.amount !== undefined && object.amount !== null
+        ? BigInt(object.amount.toString())
+        : BigInt(0);
+    return message;
+  },
+  fromProtoMsg(message: QuerySupplyResponseProtoMsg): QuerySupplyResponse {
+    return QuerySupplyResponse.decode(message.value);
+  },
+  toProto(message: QuerySupplyResponse): Uint8Array {
+    return QuerySupplyResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QuerySupplyResponse): QuerySupplyResponseProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.QuerySupplyResponse',
+      value: QuerySupplyResponse.encode(message).finish(),
+    };
+  },
+};
+function createBaseQueryNFTsRequest(): QueryNFTsRequest {
+  return {
+    classId: '',
+    owner: '',
+    pagination: undefined,
+  };
+}
+export const QueryNFTsRequest = {
+  typeUrl: '/cosmos.nft.v1beta1.QueryNFTsRequest',
+  encode(
+    message: QueryNFTsRequest,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.classId !== '') {
+      writer.uint32(10).string(message.classId);
+    }
+    if (message.owner !== '') {
+      writer.uint32(18).string(message.owner);
+    }
+    if (message.pagination !== undefined) {
+      PageRequest.encode(message.pagination, writer.uint32(26).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryNFTsRequest {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryNFTsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.classId = reader.string();
+          break;
+        case 2:
+          message.owner = reader.string();
+          break;
+        case 3:
+          message.pagination = PageRequest.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryNFTsRequest {
+    return {
+      classId: isSet(object.classId) ? String(object.classId) : '',
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      pagination: isSet(object.pagination)
+        ? PageRequest.fromJSON(object.pagination)
+        : undefined,
+    };
+  },
+  toJSON(message: QueryNFTsRequest): JsonSafe<QueryNFTsRequest> {
+    const obj: any = {};
+    message.classId !== undefined && (obj.classId = message.classId);
+    message.owner !== undefined && (obj.owner = message.owner);
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryNFTsRequest>): QueryNFTsRequest {
+    const message = createBaseQueryNFTsRequest();
+    message.classId = object.classId ?? '';
+    message.owner = object.owner ?? '';
+    message.pagination =
+      object.pagination !== undefined && object.pagination !== null
+        ? PageRequest.fromPartial(object.pagination)
+        : undefined;
+    return message;
+  },
+  fromProtoMsg(message: QueryNFTsRequestProtoMsg): QueryNFTsRequest {
+    return QueryNFTsRequest.decode(message.value);
+  },
+  toProto(message: QueryNFTsRequest): Uint8Array {
+    return QueryNFTsRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryNFTsRequest): QueryNFTsRequestProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.QueryNFTsRequest',
+      value: QueryNFTsRequest.encode(message).finish(),
+    };
+  },
+};
+function createBaseQueryNFTsResponse(): QueryNFTsResponse {
+  return {
+    nfts: [],
+    pagination: undefined,
+  };
+}
+export const QueryNFTsResponse = {
+  typeUrl: '/cosmos.nft.v1beta1.QueryNFTsResponse',
+  encode(
+    message: QueryNFTsResponse,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    for (const v of message.nfts) {
+      NFT.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.pagination !== undefined) {
+      PageResponse.encode(
+        message.pagination,
+        writer.uint32(18).fork(),
+      ).ldelim();
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryNFTsResponse {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryNFTsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.nfts.push(NFT.decode(reader, reader.uint32()));
+          break;
+        case 2:
+          message.pagination = PageResponse.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryNFTsResponse {
+    return {
+      nfts: Array.isArray(object?.nfts)
+        ? object.nfts.map((e: any) => NFT.fromJSON(e))
+        : [],
+      pagination: isSet(object.pagination)
+        ? PageResponse.fromJSON(object.pagination)
+        : undefined,
+    };
+  },
+  toJSON(message: QueryNFTsResponse): JsonSafe<QueryNFTsResponse> {
+    const obj: any = {};
+    if (message.nfts) {
+      obj.nfts = message.nfts.map(e => (e ? NFT.toJSON(e) : undefined));
+    } else {
+      obj.nfts = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryNFTsResponse>): QueryNFTsResponse {
+    const message = createBaseQueryNFTsResponse();
+    message.nfts = object.nfts?.map(e => NFT.fromPartial(e)) || [];
+    message.pagination =
+      object.pagination !== undefined && object.pagination !== null
+        ? PageResponse.fromPartial(object.pagination)
+        : undefined;
+    return message;
+  },
+  fromProtoMsg(message: QueryNFTsResponseProtoMsg): QueryNFTsResponse {
+    return QueryNFTsResponse.decode(message.value);
+  },
+  toProto(message: QueryNFTsResponse): Uint8Array {
+    return QueryNFTsResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryNFTsResponse): QueryNFTsResponseProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.QueryNFTsResponse',
+      value: QueryNFTsResponse.encode(message).finish(),
+    };
+  },
+};
+function createBaseQueryNFTRequest(): QueryNFTRequest {
+  return {
+    classId: '',
+    id: '',
+  };
+}
+export const QueryNFTRequest = {
+  typeUrl: '/cosmos.nft.v1beta1.QueryNFTRequest',
+  encode(
+    message: QueryNFTRequest,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.classId !== '') {
+      writer.uint32(10).string(message.classId);
+    }
+    if (message.id !== '') {
+      writer.uint32(18).string(message.id);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryNFTRequest {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryNFTRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.classId = reader.string();
+          break;
+        case 2:
+          message.id = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryNFTRequest {
+    return {
+      classId: isSet(object.classId) ? String(object.classId) : '',
+      id: isSet(object.id) ? String(object.id) : '',
+    };
+  },
+  toJSON(message: QueryNFTRequest): JsonSafe<QueryNFTRequest> {
+    const obj: any = {};
+    message.classId !== undefined && (obj.classId = message.classId);
+    message.id !== undefined && (obj.id = message.id);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryNFTRequest>): QueryNFTRequest {
+    const message = createBaseQueryNFTRequest();
+    message.classId = object.classId ?? '';
+    message.id = object.id ?? '';
+    return message;
+  },
+  fromProtoMsg(message: QueryNFTRequestProtoMsg): QueryNFTRequest {
+    return QueryNFTRequest.decode(message.value);
+  },
+  toProto(message: QueryNFTRequest): Uint8Array {
+    return QueryNFTRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryNFTRequest): QueryNFTRequestProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.QueryNFTRequest',
+      value: QueryNFTRequest.encode(message).finish(),
+    };
+  },
+};
+function createBaseQueryNFTResponse(): QueryNFTResponse {
+  return {
+    nft: undefined,
+  };
+}
+export const QueryNFTResponse = {
+  typeUrl: '/cosmos.nft.v1beta1.QueryNFTResponse',
+  encode(
+    message: QueryNFTResponse,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.nft !== undefined) {
+      NFT.encode(message.nft, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryNFTResponse {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryNFTResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.nft = NFT.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryNFTResponse {
+    return {
+      nft: isSet(object.nft) ? NFT.fromJSON(object.nft) : undefined,
+    };
+  },
+  toJSON(message: QueryNFTResponse): JsonSafe<QueryNFTResponse> {
+    const obj: any = {};
+    message.nft !== undefined &&
+      (obj.nft = message.nft ? NFT.toJSON(message.nft) : undefined);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryNFTResponse>): QueryNFTResponse {
+    const message = createBaseQueryNFTResponse();
+    message.nft =
+      object.nft !== undefined && object.nft !== null
+        ? NFT.fromPartial(object.nft)
+        : undefined;
+    return message;
+  },
+  fromProtoMsg(message: QueryNFTResponseProtoMsg): QueryNFTResponse {
+    return QueryNFTResponse.decode(message.value);
+  },
+  toProto(message: QueryNFTResponse): Uint8Array {
+    return QueryNFTResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryNFTResponse): QueryNFTResponseProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.QueryNFTResponse',
+      value: QueryNFTResponse.encode(message).finish(),
+    };
+  },
+};
+function createBaseQueryClassRequest(): QueryClassRequest {
+  return {
+    classId: '',
+  };
+}
+export const QueryClassRequest = {
+  typeUrl: '/cosmos.nft.v1beta1.QueryClassRequest',
+  encode(
+    message: QueryClassRequest,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.classId !== '') {
+      writer.uint32(10).string(message.classId);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryClassRequest {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryClassRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.classId = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryClassRequest {
+    return {
+      classId: isSet(object.classId) ? String(object.classId) : '',
+    };
+  },
+  toJSON(message: QueryClassRequest): JsonSafe<QueryClassRequest> {
+    const obj: any = {};
+    message.classId !== undefined && (obj.classId = message.classId);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryClassRequest>): QueryClassRequest {
+    const message = createBaseQueryClassRequest();
+    message.classId = object.classId ?? '';
+    return message;
+  },
+  fromProtoMsg(message: QueryClassRequestProtoMsg): QueryClassRequest {
+    return QueryClassRequest.decode(message.value);
+  },
+  toProto(message: QueryClassRequest): Uint8Array {
+    return QueryClassRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryClassRequest): QueryClassRequestProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.QueryClassRequest',
+      value: QueryClassRequest.encode(message).finish(),
+    };
+  },
+};
+function createBaseQueryClassResponse(): QueryClassResponse {
+  return {
+    class: undefined,
+  };
+}
+export const QueryClassResponse = {
+  typeUrl: '/cosmos.nft.v1beta1.QueryClassResponse',
+  encode(
+    message: QueryClassResponse,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.class !== undefined) {
+      Class.encode(message.class, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): QueryClassResponse {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryClassResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.class = Class.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryClassResponse {
+    return {
+      class: isSet(object.class) ? Class.fromJSON(object.class) : undefined,
+    };
+  },
+  toJSON(message: QueryClassResponse): JsonSafe<QueryClassResponse> {
+    const obj: any = {};
+    message.class !== undefined &&
+      (obj.class = message.class ? Class.toJSON(message.class) : undefined);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryClassResponse>): QueryClassResponse {
+    const message = createBaseQueryClassResponse();
+    message.class =
+      object.class !== undefined && object.class !== null
+        ? Class.fromPartial(object.class)
+        : undefined;
+    return message;
+  },
+  fromProtoMsg(message: QueryClassResponseProtoMsg): QueryClassResponse {
+    return QueryClassResponse.decode(message.value);
+  },
+  toProto(message: QueryClassResponse): Uint8Array {
+    return QueryClassResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryClassResponse): QueryClassResponseProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.QueryClassResponse',
+      value: QueryClassResponse.encode(message).finish(),
+    };
+  },
+};
+function createBaseQueryClassesRequest(): QueryClassesRequest {
+  return {
+    pagination: undefined,
+  };
+}
+export const QueryClassesRequest = {
+  typeUrl: '/cosmos.nft.v1beta1.QueryClassesRequest',
+  encode(
+    message: QueryClassesRequest,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.pagination !== undefined) {
+      PageRequest.encode(message.pagination, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): QueryClassesRequest {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryClassesRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.pagination = PageRequest.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryClassesRequest {
+    return {
+      pagination: isSet(object.pagination)
+        ? PageRequest.fromJSON(object.pagination)
+        : undefined,
+    };
+  },
+  toJSON(message: QueryClassesRequest): JsonSafe<QueryClassesRequest> {
+    const obj: any = {};
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryClassesRequest>): QueryClassesRequest {
+    const message = createBaseQueryClassesRequest();
+    message.pagination =
+      object.pagination !== undefined && object.pagination !== null
+        ? PageRequest.fromPartial(object.pagination)
+        : undefined;
+    return message;
+  },
+  fromProtoMsg(message: QueryClassesRequestProtoMsg): QueryClassesRequest {
+    return QueryClassesRequest.decode(message.value);
+  },
+  toProto(message: QueryClassesRequest): Uint8Array {
+    return QueryClassesRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryClassesRequest): QueryClassesRequestProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.QueryClassesRequest',
+      value: QueryClassesRequest.encode(message).finish(),
+    };
+  },
+};
+function createBaseQueryClassesResponse(): QueryClassesResponse {
+  return {
+    classes: [],
+    pagination: undefined,
+  };
+}
+export const QueryClassesResponse = {
+  typeUrl: '/cosmos.nft.v1beta1.QueryClassesResponse',
+  encode(
+    message: QueryClassesResponse,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    for (const v of message.classes) {
+      Class.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.pagination !== undefined) {
+      PageResponse.encode(
+        message.pagination,
+        writer.uint32(18).fork(),
+      ).ldelim();
+    }
+    return writer;
+  },
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): QueryClassesResponse {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryClassesResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.classes.push(Class.decode(reader, reader.uint32()));
+          break;
+        case 2:
+          message.pagination = PageResponse.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryClassesResponse {
+    return {
+      classes: Array.isArray(object?.classes)
+        ? object.classes.map((e: any) => Class.fromJSON(e))
+        : [],
+      pagination: isSet(object.pagination)
+        ? PageResponse.fromJSON(object.pagination)
+        : undefined,
+    };
+  },
+  toJSON(message: QueryClassesResponse): JsonSafe<QueryClassesResponse> {
+    const obj: any = {};
+    if (message.classes) {
+      obj.classes = message.classes.map(e => (e ? Class.toJSON(e) : undefined));
+    } else {
+      obj.classes = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryClassesResponse>): QueryClassesResponse {
+    const message = createBaseQueryClassesResponse();
+    message.classes = object.classes?.map(e => Class.fromPartial(e)) || [];
+    message.pagination =
+      object.pagination !== undefined && object.pagination !== null
+        ? PageResponse.fromPartial(object.pagination)
+        : undefined;
+    return message;
+  },
+  fromProtoMsg(message: QueryClassesResponseProtoMsg): QueryClassesResponse {
+    return QueryClassesResponse.decode(message.value);
+  },
+  toProto(message: QueryClassesResponse): Uint8Array {
+    return QueryClassesResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryClassesResponse): QueryClassesResponseProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.QueryClassesResponse',
+      value: QueryClassesResponse.encode(message).finish(),
+    };
+  },
+};

--- a/packages/cosmic-proto/src/codegen/cosmos/nft/v1beta1/tx.ts
+++ b/packages/cosmic-proto/src/codegen/cosmos/nft/v1beta1/tx.ts
@@ -1,0 +1,176 @@
+//@ts-nocheck
+import { BinaryReader, BinaryWriter } from '../../../binary.js';
+import { isSet } from '../../../helpers.js';
+import { JsonSafe } from '../../../json-safe.js';
+/** MsgSend represents a message to send a nft from one account to another account. */
+export interface MsgSend {
+  /** class_id defines the unique identifier of the nft classification, similar to the contract address of ERC721 */
+  classId: string;
+  /** id defines the unique identification of nft */
+  id: string;
+  /** sender is the address of the owner of nft */
+  sender: string;
+  /** receiver is the receiver address of nft */
+  receiver: string;
+}
+export interface MsgSendProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.MsgSend';
+  value: Uint8Array;
+}
+/** MsgSend represents a message to send a nft from one account to another account. */
+export interface MsgSendSDKType {
+  class_id: string;
+  id: string;
+  sender: string;
+  receiver: string;
+}
+/** MsgSendResponse defines the Msg/Send response type. */
+export interface MsgSendResponse {}
+export interface MsgSendResponseProtoMsg {
+  typeUrl: '/cosmos.nft.v1beta1.MsgSendResponse';
+  value: Uint8Array;
+}
+/** MsgSendResponse defines the Msg/Send response type. */
+export interface MsgSendResponseSDKType {}
+function createBaseMsgSend(): MsgSend {
+  return {
+    classId: '',
+    id: '',
+    sender: '',
+    receiver: '',
+  };
+}
+export const MsgSend = {
+  typeUrl: '/cosmos.nft.v1beta1.MsgSend',
+  encode(
+    message: MsgSend,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    if (message.classId !== '') {
+      writer.uint32(10).string(message.classId);
+    }
+    if (message.id !== '') {
+      writer.uint32(18).string(message.id);
+    }
+    if (message.sender !== '') {
+      writer.uint32(26).string(message.sender);
+    }
+    if (message.receiver !== '') {
+      writer.uint32(34).string(message.receiver);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): MsgSend {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgSend();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.classId = reader.string();
+          break;
+        case 2:
+          message.id = reader.string();
+          break;
+        case 3:
+          message.sender = reader.string();
+          break;
+        case 4:
+          message.receiver = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): MsgSend {
+    return {
+      classId: isSet(object.classId) ? String(object.classId) : '',
+      id: isSet(object.id) ? String(object.id) : '',
+      sender: isSet(object.sender) ? String(object.sender) : '',
+      receiver: isSet(object.receiver) ? String(object.receiver) : '',
+    };
+  },
+  toJSON(message: MsgSend): JsonSafe<MsgSend> {
+    const obj: any = {};
+    message.classId !== undefined && (obj.classId = message.classId);
+    message.id !== undefined && (obj.id = message.id);
+    message.sender !== undefined && (obj.sender = message.sender);
+    message.receiver !== undefined && (obj.receiver = message.receiver);
+    return obj;
+  },
+  fromPartial(object: Partial<MsgSend>): MsgSend {
+    const message = createBaseMsgSend();
+    message.classId = object.classId ?? '';
+    message.id = object.id ?? '';
+    message.sender = object.sender ?? '';
+    message.receiver = object.receiver ?? '';
+    return message;
+  },
+  fromProtoMsg(message: MsgSendProtoMsg): MsgSend {
+    return MsgSend.decode(message.value);
+  },
+  toProto(message: MsgSend): Uint8Array {
+    return MsgSend.encode(message).finish();
+  },
+  toProtoMsg(message: MsgSend): MsgSendProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.MsgSend',
+      value: MsgSend.encode(message).finish(),
+    };
+  },
+};
+function createBaseMsgSendResponse(): MsgSendResponse {
+  return {};
+}
+export const MsgSendResponse = {
+  typeUrl: '/cosmos.nft.v1beta1.MsgSendResponse',
+  encode(
+    _: MsgSendResponse,
+    writer: BinaryWriter = BinaryWriter.create(),
+  ): BinaryWriter {
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): MsgSendResponse {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgSendResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(_: any): MsgSendResponse {
+    return {};
+  },
+  toJSON(_: MsgSendResponse): JsonSafe<MsgSendResponse> {
+    const obj: any = {};
+    return obj;
+  },
+  fromPartial(_: Partial<MsgSendResponse>): MsgSendResponse {
+    const message = createBaseMsgSendResponse();
+    return message;
+  },
+  fromProtoMsg(message: MsgSendResponseProtoMsg): MsgSendResponse {
+    return MsgSendResponse.decode(message.value);
+  },
+  toProto(message: MsgSendResponse): Uint8Array {
+    return MsgSendResponse.encode(message).finish();
+  },
+  toProtoMsg(message: MsgSendResponse): MsgSendResponseProtoMsg {
+    return {
+      typeUrl: '/cosmos.nft.v1beta1.MsgSendResponse',
+      value: MsgSendResponse.encode(message).finish(),
+    };
+  },
+};

--- a/packages/cosmic-proto/src/codegen/gogoproto/bundle.ts
+++ b/packages/cosmic-proto/src/codegen/gogoproto/bundle.ts
@@ -1,5 +1,5 @@
 //@ts-nocheck
-import * as _80 from './gogo.js';
+import * as _85 from './gogo.js';
 export const gogoproto = {
-  ..._80,
+  ..._85,
 };

--- a/packages/cosmic-proto/src/codegen/google/bundle.ts
+++ b/packages/cosmic-proto/src/codegen/google/bundle.ts
@@ -1,15 +1,15 @@
 //@ts-nocheck
-import * as _81 from './protobuf/any.js';
-import * as _82 from './protobuf/descriptor.js';
-import * as _83 from './protobuf/duration.js';
-import * as _84 from './protobuf/empty.js';
-import * as _85 from './protobuf/timestamp.js';
+import * as _86 from './protobuf/any.js';
+import * as _87 from './protobuf/descriptor.js';
+import * as _88 from './protobuf/duration.js';
+import * as _89 from './protobuf/empty.js';
+import * as _90 from './protobuf/timestamp.js';
 export namespace google {
   export const protobuf = {
-    ..._81,
-    ..._82,
-    ..._83,
-    ..._84,
-    ..._85,
+    ..._86,
+    ..._87,
+    ..._88,
+    ..._89,
+    ..._90,
   };
 }

--- a/packages/cosmic-proto/src/codegen/ibc/bundle.ts
+++ b/packages/cosmic-proto/src/codegen/ibc/bundle.ts
@@ -1,99 +1,86 @@
 //@ts-nocheck
-import * as _86 from './applications/interchain_accounts/controller/v1/controller.js';
-import * as _87 from './applications/interchain_accounts/controller/v1/query.js';
-import * as _88 from './applications/interchain_accounts/controller/v1/tx.js';
-import * as _89 from './applications/interchain_accounts/genesis/v1/genesis.js';
-import * as _90 from './applications/interchain_accounts/host/v1/host.js';
-import * as _91 from './applications/interchain_accounts/host/v1/query.js';
-import * as _92 from './applications/interchain_accounts/v1/account.js';
-import * as _93 from './applications/interchain_accounts/v1/metadata.js';
-import * as _94 from './applications/interchain_accounts/v1/packet.js';
-import * as _95 from './applications/transfer/v1/authz.js';
-import * as _96 from './applications/transfer/v1/genesis.js';
-import * as _97 from './applications/transfer/v1/query.js';
-import * as _98 from './applications/transfer/v1/transfer.js';
-import * as _99 from './applications/transfer/v1/tx.js';
-import * as _100 from './applications/transfer/v2/packet.js';
-import * as _101 from './core/channel/v1/channel.js';
-import * as _102 from './core/channel/v1/genesis.js';
-import * as _103 from './core/channel/v1/query.js';
-import * as _104 from './core/channel/v1/tx.js';
-import * as _105 from './core/client/v1/client.js';
-import * as _106 from './core/client/v1/genesis.js';
-import * as _107 from './core/client/v1/query.js';
-import * as _108 from './core/client/v1/tx.js';
-import * as _109 from './core/commitment/v1/commitment.js';
-import * as _110 from './core/connection/v1/connection.js';
-import * as _111 from './core/connection/v1/genesis.js';
-import * as _112 from './core/connection/v1/query.js';
-import * as _113 from './core/connection/v1/tx.js';
-import * as _114 from './lightclients/localhost/v1/localhost.js';
-import * as _115 from './lightclients/solomachine/v1/solomachine.js';
-import * as _116 from './lightclients/solomachine/v2/solomachine.js';
-import * as _117 from './lightclients/tendermint/v1/tendermint.js';
+import * as _91 from './applications/interchain_accounts/controller/v1/controller.js';
+import * as _92 from './applications/interchain_accounts/controller/v1/query.js';
+import * as _93 from './applications/interchain_accounts/controller/v1/tx.js';
+import * as _94 from './applications/interchain_accounts/genesis/v1/genesis.js';
+import * as _95 from './applications/interchain_accounts/host/v1/host.js';
+import * as _96 from './applications/interchain_accounts/host/v1/query.js';
+import * as _97 from './applications/interchain_accounts/v1/account.js';
+import * as _98 from './applications/interchain_accounts/v1/metadata.js';
+import * as _99 from './applications/interchain_accounts/v1/packet.js';
+import * as _100 from './applications/transfer/v1/authz.js';
+import * as _101 from './applications/transfer/v1/genesis.js';
+import * as _102 from './applications/transfer/v1/query.js';
+import * as _103 from './applications/transfer/v1/transfer.js';
+import * as _104 from './applications/transfer/v1/tx.js';
+import * as _105 from './applications/transfer/v2/packet.js';
+import * as _106 from './core/channel/v1/channel.js';
+import * as _107 from './core/channel/v1/genesis.js';
+import * as _108 from './core/channel/v1/query.js';
+import * as _109 from './core/channel/v1/tx.js';
+import * as _110 from './core/client/v1/client.js';
+import * as _111 from './core/client/v1/genesis.js';
+import * as _112 from './core/client/v1/query.js';
+import * as _113 from './core/client/v1/tx.js';
+import * as _114 from './core/commitment/v1/commitment.js';
+import * as _115 from './core/connection/v1/connection.js';
+import * as _116 from './core/connection/v1/genesis.js';
+import * as _117 from './core/connection/v1/query.js';
+import * as _118 from './core/connection/v1/tx.js';
+import * as _119 from './lightclients/localhost/v1/localhost.js';
+import * as _120 from './lightclients/solomachine/v1/solomachine.js';
+import * as _121 from './lightclients/solomachine/v2/solomachine.js';
+import * as _122 from './lightclients/tendermint/v1/tendermint.js';
 export namespace ibc {
   export namespace applications {
     export namespace interchain_accounts {
       export namespace controller {
         export const v1 = {
-          ..._86,
-          ..._87,
-          ..._88,
+          ..._91,
+          ..._92,
+          ..._93,
         };
       }
       export namespace genesis {
         export const v1 = {
-          ..._89,
+          ..._94,
         };
       }
       export namespace host {
         export const v1 = {
-          ..._90,
-          ..._91,
+          ..._95,
+          ..._96,
         };
       }
       export const v1 = {
-        ..._92,
-        ..._93,
-        ..._94,
-      };
-    }
-    export namespace transfer {
-      export const v1 = {
-        ..._95,
-        ..._96,
         ..._97,
         ..._98,
         ..._99,
       };
-      export const v2 = {
+    }
+    export namespace transfer {
+      export const v1 = {
         ..._100,
+        ..._101,
+        ..._102,
+        ..._103,
+        ..._104,
+      };
+      export const v2 = {
+        ..._105,
       };
     }
   }
   export namespace core {
     export namespace channel {
       export const v1 = {
-        ..._101,
-        ..._102,
-        ..._103,
-        ..._104,
-      };
-    }
-    export namespace client {
-      export const v1 = {
-        ..._105,
         ..._106,
         ..._107,
         ..._108,
-      };
-    }
-    export namespace commitment {
-      export const v1 = {
         ..._109,
       };
     }
-    export namespace connection {
+    export namespace client {
       export const v1 = {
         ..._110,
         ..._111,
@@ -101,24 +88,37 @@ export namespace ibc {
         ..._113,
       };
     }
-  }
-  export namespace lightclients {
-    export namespace localhost {
+    export namespace commitment {
       export const v1 = {
         ..._114,
       };
     }
-    export namespace solomachine {
+    export namespace connection {
       export const v1 = {
         ..._115,
+        ..._116,
+        ..._117,
+        ..._118,
+      };
+    }
+  }
+  export namespace lightclients {
+    export namespace localhost {
+      export const v1 = {
+        ..._119,
+      };
+    }
+    export namespace solomachine {
+      export const v1 = {
+        ..._120,
       };
       export const v2 = {
-        ..._116,
+        ..._121,
       };
     }
     export namespace tendermint {
       export const v1 = {
-        ..._117,
+        ..._122,
       };
     }
   }

--- a/packages/cosmic-proto/src/codegen/icq/bundle.ts
+++ b/packages/cosmic-proto/src/codegen/icq/bundle.ts
@@ -1,15 +1,15 @@
 //@ts-nocheck
-import * as _118 from './v1/genesis.js';
-import * as _119 from './v1/icq.js';
-import * as _120 from './v1/packet.js';
-import * as _121 from './v1/query.js';
-import * as _122 from './v1/tx.js';
+import * as _123 from './v1/genesis.js';
+import * as _124 from './v1/icq.js';
+import * as _125 from './v1/packet.js';
+import * as _126 from './v1/query.js';
+import * as _127 from './v1/tx.js';
 export namespace icq {
   export const v1 = {
-    ..._118,
-    ..._119,
-    ..._120,
-    ..._121,
-    ..._122,
+    ..._123,
+    ..._124,
+    ..._125,
+    ..._126,
+    ..._127,
   };
 }

--- a/packages/cosmic-proto/src/codegen/ics23/bundle.ts
+++ b/packages/cosmic-proto/src/codegen/ics23/bundle.ts
@@ -1,5 +1,5 @@
 //@ts-nocheck
-import * as _123 from '../proofs.js';
+import * as _128 from '../proofs.js';
 export const ics23 = {
-  ..._123,
+  ..._128,
 };

--- a/packages/cosmic-proto/src/codegen/tendermint/bundle.ts
+++ b/packages/cosmic-proto/src/codegen/tendermint/bundle.ts
@@ -1,39 +1,39 @@
 //@ts-nocheck
-import * as _124 from './abci/types.js';
-import * as _125 from './crypto/keys.js';
-import * as _126 from './crypto/proof.js';
-import * as _127 from './libs/bits/types.js';
-import * as _128 from './p2p/types.js';
-import * as _129 from './types/block.js';
-import * as _130 from './types/evidence.js';
-import * as _131 from './types/params.js';
-import * as _132 from './types/types.js';
-import * as _133 from './types/validator.js';
-import * as _134 from './version/types.js';
+import * as _129 from './abci/types.js';
+import * as _130 from './crypto/keys.js';
+import * as _131 from './crypto/proof.js';
+import * as _132 from './libs/bits/types.js';
+import * as _133 from './p2p/types.js';
+import * as _134 from './types/block.js';
+import * as _135 from './types/evidence.js';
+import * as _136 from './types/params.js';
+import * as _137 from './types/types.js';
+import * as _138 from './types/validator.js';
+import * as _139 from './version/types.js';
 export namespace tendermint {
   export const abci = {
-    ..._124,
+    ..._129,
   };
   export const crypto = {
-    ..._125,
-    ..._126,
+    ..._130,
+    ..._131,
   };
   export namespace libs {
     export const bits = {
-      ..._127,
+      ..._132,
     };
   }
   export const p2p = {
-    ..._128,
-  };
-  export const types = {
-    ..._129,
-    ..._130,
-    ..._131,
-    ..._132,
     ..._133,
   };
-  export const version = {
+  export const types = {
     ..._134,
+    ..._135,
+    ..._136,
+    ..._137,
+    ..._138,
+  };
+  export const version = {
+    ..._139,
   };
 }

--- a/packages/orchestration/src/exos/nftKit.js
+++ b/packages/orchestration/src/exos/nftKit.js
@@ -1,0 +1,83 @@
+import { M } from '@endo/patterns';
+import { E } from '@endo/far';
+import { TopicsRecordShape } from '@agoric/zoe/src/contractSupport/index.js';
+import { ChainAddressShape, NftShape } from '../typeGuards.js';
+import {
+  QueryNFTsRequest,
+  QueryNFTsResponse,
+} from '@agoric/cosmic-proto/cosmos/nft/v1beta1/query.js';
+import { toRequestQueryJson } from '@agoric/cosmic-proto';
+import { Fail } from '@agoric/assert';
+import { decodeBase64 } from '@endo/base64';
+
+/**
+ * @param {import('@agoric/zone').Zone} zone
+ * @param {ZCF} zcf
+ */
+export const prepareNftKit = (zone, zcf) => {
+  const makeNftKit = zone.exoClassKit(
+    'Nft Account Holder',
+    {
+      helper: M.interface('helper', {
+        toNftDenomAmount: M.call(M.string()).returns(M.any()),
+      }),
+      invitationMakers: M.interface('invitationMakers', {
+        send: M.call().returns(M.any()),
+      }),
+      holder: M.interface('IcaAccountHolder', {
+        getPublicTopics: M.call().returns(TopicsRecordShape),
+        getAddress: M.call().returns(ChainAddressShape),
+        getBalance: M.call(M.string()).returns(NftShape),
+        getBalances: M.call().returns(M.arrayOf(NftShape)),
+      }),
+    },
+    /**
+     * @param {import('../types.js').ChainAddress} chainAddress
+     * @param {import('../types.js').IcaAccount} account
+     * @param {import('../types.js').ICQConnection} icqConnection
+     * @param {string} nftDenom
+     * @param {StorageNode} storageNode
+     */
+    (chainAddress, account, icqConnection, nftDenom, storageNode) => {
+      return { chainAddress, account, icqConnection, nftDenom };
+    },
+    {
+      helper: {
+        toNftDenomAmount(nft) {},
+      },
+
+      invitationMakers: {
+        async send(nftAmount, address) {},
+      },
+
+      holder: {
+        getAddress() {
+          return this.state.chainAddress;
+        },
+        async getBalance(denom) {
+          const { toNftDenomAmount } = this.facets.helper;
+          const { chainAddress, icqConnection, nftDenom } = this.state;
+          denom ||= nftDenom;
+          assert.typeof(denom, 'string');
+
+          const [result] = await E(icqConnection).query([
+            toRequestQueryJson(
+              QueryNFTsRequest.toProtoMsg({
+                classId: denom,
+                owner: chainAddress.address,
+              }),
+            ),
+          ]);
+
+          if (!result?.key) throw Fail`Error parsing result ${result}`;
+          const { nfts } = QueryNFTsResponse.decode(decodeBase64(result.key));
+          if (!nfts) throw Fail`Result lacked balance key: ${result}`;
+
+          return harden(toNftDenomAmount(nfts));
+        },
+        async getBalances() {},
+      },
+    },
+  );
+  return harden({ makeNftKit });
+};

--- a/packages/orchestration/src/exos/nftKit.js
+++ b/packages/orchestration/src/exos/nftKit.js
@@ -2,13 +2,18 @@ import { M } from '@endo/patterns';
 import { E } from '@endo/far';
 import { TopicsRecordShape } from '@agoric/zoe/src/contractSupport/index.js';
 import { ChainAddressShape, NftShape } from '../typeGuards.js';
+import { toRequestQueryJson } from '@agoric/cosmic-proto';
+import { Fail } from '@agoric/assert';
+import { decodeBase64 } from '@endo/base64';
+import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
 import {
   QueryNFTsRequest,
   QueryNFTsResponse,
 } from '@agoric/cosmic-proto/cosmos/nft/v1beta1/query.js';
-import { toRequestQueryJson } from '@agoric/cosmic-proto';
-import { Fail } from '@agoric/assert';
-import { decodeBase64 } from '@endo/base64';
+import {
+  MsgSend,
+  MsgSendResponse,
+} from '@agoric/cosmic-proto/cosmos/nft/v1beta1/tx.js';
 
 /**
  * @param {import('@agoric/zone').Zone} zone
@@ -21,14 +26,12 @@ export const prepareNftKit = (zone, zcf) => {
       helper: M.interface('helper', {
         toNftDenomAmount: M.call(M.string()).returns(M.any()),
       }),
-      invitationMakers: M.interface('invitationMakers', {
-        send: M.call().returns(M.any()),
-      }),
       holder: M.interface('IcaAccountHolder', {
         getPublicTopics: M.call().returns(TopicsRecordShape),
         getAddress: M.call().returns(ChainAddressShape),
         getBalance: M.call(M.string()).returns(NftShape),
         getBalances: M.call().returns(M.arrayOf(NftShape)),
+        send: M.call().returns(M.any()),
       }),
     },
     /**
@@ -45,14 +48,9 @@ export const prepareNftKit = (zone, zcf) => {
       helper: {
         toNftDenomAmount(nft) {},
       },
-
-      invitationMakers: {
-        async send(nftAmount, address) {},
-      },
-
       holder: {
         getAddress() {
-          return this.state.chainAddress;
+          return this.state.chainAddress.address;
         },
         async getBalance(denom) {
           const { toNftDenomAmount } = this.facets.helper;
@@ -75,7 +73,43 @@ export const prepareNftKit = (zone, zcf) => {
 
           return harden(toNftDenomAmount(nfts));
         },
-        async getBalances() {},
+        async getBalances() {
+          const { toNftDenomAmount } = this.facets.helper;
+          const { chainAddress, icqConnection } = this.state;
+
+          /* Based on the protobuf definition for QueryNFTsRequest,
+           * it should be possible to provide only the owner as argument
+           */
+          const [result] = await E(icqConnection).query([
+            toRequestQueryJson(
+              QueryNFTsRequest.toProtoMsg({
+                owner: chainAddress.address,
+                classId: '',
+              }),
+            ),
+          ]);
+
+          if (!result?.key) throw Fail`Error parsing result ${result}`;
+          const { nfts } = QueryNFTsResponse.decode(decodeBase64(result.key));
+          if (!nfts) throw Fail`Result lacked balance key: ${result}`;
+
+          return harden(toNftDenomAmount(nfts));
+        },
+        async send(nftAmount, address) {
+          const { account } = this.state;
+          const classId = this.state.nftDenom || nftAmount.brand;
+
+          await E(account).executeEncodedTx([
+            Any.toJSON(
+              MsgSend.toProtoMsg({
+                classId: classId,
+                id: nftAmount.value.id,
+                sender: this.state.chainAddress.address,
+                receiver: address,
+              }),
+            ),
+          ]);
+        },
       },
     },
   );

--- a/packages/orchestration/src/facade.js
+++ b/packages/orchestration/src/facade.js
@@ -179,6 +179,7 @@ export const makeOrchestrationFacade = ({
         },
         getBrandInfo: anyVal,
         asAmount: anyVal,
+        asNftAmount: anyVal,
       };
       return async (...args) => fn(orc, ctx, ...args);
     },

--- a/packages/orchestration/src/orchestration-api.ts
+++ b/packages/orchestration/src/orchestration-api.ts
@@ -60,7 +60,7 @@ export type NftDenom = string;
 export type NftDenomArg = NftDenom | Brand;
 
 export type NftDenomAmount = {
-  brand: NftDenom;
+  denom: NftDenom;
   value: {
     id: string;
     uri: string;

--- a/packages/orchestration/src/orchestration-api.ts
+++ b/packages/orchestration/src/orchestration-api.ts
@@ -146,7 +146,7 @@ export interface Orchestrator {
    */
   asNftAmount: (
     amount: NftDenomAmount,
-  ) => CopySetAmount<NftDenomAmount['brand']> | CopyBagAmount<NftDenomAmount['brand']>;
+  ) => CopyBagAmount<NftDenomAmount['denom']>;
 }
 
 /**

--- a/packages/orchestration/src/typeGuards.js
+++ b/packages/orchestration/src/typeGuards.js
@@ -37,3 +37,7 @@ export const IBCTransferOptionsShape = M.splitRecord(
     memo: M.string(),
   },
 );
+
+export const NftShape = { nftDenom: M.string(), value: M.record() };
+
+export const NftAmountShape = harden({ nftDenom: M.string(), value: M.bag() });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

refs: #33

## Description

This PR aims to extend the Agoric `Orchestration` package to support the cosmos `NFT` module, more specifically, providing a kit that exposes methods to: 
- query all NFTs held on an Interchain Account 
- query all NFTs from a specific Class held on an Interchain Account 
- transfer the NFT to other address in that chain

In order to implement the methods above, it is necessary to:
- convert the [NFT](https://buf.build/cosmos/cosmos-sdk/docs/main:cosmos.nft.v1beta1#cosmos.nft.v1beta1.NFT) into an ERTP asset
- map a defined `denom` that identifies the [Class](https://buf.build/cosmos/cosmos-sdk/docs/main:cosmos.nft.v1beta1#cosmos.nft.v1beta1.Class) and `host chain` with the local `Issuer` and `Brand` objects 


Note: based on the commit [e436743](https://github.com/Agoric/agoric-sdk/commit/e43674374a6eece4d0b73b04ee7387c8e3354d05), it is reasonable to assume that the `NftKit` features may be implemented under the `cosmosOrchestrationAccount` instead of a dedicated exo-kit.

### Security Considerations

To be done ...

### Documentation Considerations

For a better perception of the changes implemented, we advise to generate the api spec of the Orchestration package:
```bash
yarn install && yarn build
cd packages/orchestration
yarn typedoc
open docs/index.html
```

At the issue #33, a description of the logic behind the changes implemented can be found with the support of diagrams.

### Testing Considerations

To be done ...

### Upgrade Considerations

To be done ...
